### PR TITLE
add github action

### DIFF
--- a/.github/workflows/sample_github_action.yaml
+++ b/.github/workflows/sample_github_action.yaml
@@ -1,0 +1,23 @@
+name: Sample Dotnet Snyk Test
+
+on:
+  push:
+    branches: [ dev, add-github-action ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Check out source"
+        uses: actions/checkout@v2.4.0
+
+      - name: "Run dotnet restore"
+        run: dotnet restore Oqtane.sln
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/dotnet@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects


### PR DESCRIPTION
I have added the step to "run dotnet restore" which will restore the dependencies and tools of the project. Snyk will use these when it runs the actual vulnerability scan

All that's needed is to add a single step before running snyk:

``` 
- name: "Run dotnet restore"
  run: dotnet restore your_solution_file.sln
```

In the GitHub Action output, you should see that Snyk ran successfully and found some vulnerabilities 